### PR TITLE
Fixed segfault on unresolvable I2P router address

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clone the repo:
 
 Install required packages:
 
-    sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libgtk-3-dev libevent-dev libminiupnpc-dev libappindicator-dev automake1.11
+    sudo apt-get install build-essential automake autoconf libtool pkg-config intltool libcurl4-openssl-dev libglib2.0-dev libgtk-3-dev libevent-dev libminiupnpc-dev libappindicator-dev libssl-dev automake1.11
 
 Then configure and make:
 


### PR DESCRIPTION
fixes #2 and https://github.com/PurpleI2P/i2pd/issues/568

If you don't want to recompile the app, as a workaround you can enter a hostname related to your I2P router address into `/etc/hosts` file.